### PR TITLE
Fix missing headers

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = stsci.ndimage
-version = 0.10.2
+version = 0.10.3
 author = STScI
 author-email = help@stsci.edu
 summary = Various functions for multi-dimensional image processing--fork of


### PR DESCRIPTION
Avoids this during tarball installation:
```    creating build/temp.macosx-10.7-x86_64-3.6/src
    gcc -Wno-unused-result -Wsign-compare -Wunreachable-code -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -I/Users/jhunk/miniconda3/envs/OMG/include -arch x86_64 -I/Users/jhunk/miniconda3/envs/OMG/include -arch x86_64 -I/Users/jhunk/miniconda3/envs/OMG/lib/python3.6/site-packages/numpy/core/include -I/Users/jhunk/miniconda3/envs/OMG/include/python3.6m -c src/nd_image.c -o build/temp.macosx-10.7-x86_64-3.6/src/nd_image.o
    src/nd_image.c:33:10: fatal error: 'nd_image.h' file not found
    #include "nd_image.h"
             ^
    1 error generated.
    error: command 'gcc' failed with exit status 1
```